### PR TITLE
fix assets_path to relative

### DIFF
--- a/etc/config/html5-example.toml
+++ b/etc/config/html5-example.toml
@@ -1,4 +1,4 @@
 [game_server]
 matching_endpoint = "ws://localhost:8080/matching"
 [html5_client_server]
-assets_path = "/Users/tomyhero/go/src/github.com/tomyhero/battleship-game/assets"
+assets_path = "assets"

--- a/html5_client/app.go
+++ b/html5_client/app.go
@@ -3,6 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+
 	"github.com/tomyhero/battleship-game/html5_client/app/game"
 	"github.com/tomyhero/battleship-game/utils"
 	"github.com/zenazn/goji"
@@ -44,4 +46,5 @@ func setupWebApp(config *utils.Config) utils.WebApp {
 
 func setupGoji(webApp utils.WebApp) {
 	goji.Handle("/game/*", game.NewMux(webApp))
+	goji.Get("/game", http.RedirectHandler("/game/", 301))
 }


### PR DESCRIPTION
Hello tomyhero.

I immediately after clone,
We've run the `$ go run html5_client/app.go`,
http://localhost:23456/game was 404.

So, we did a assets_path in relative path.
After, it was in to redirect the /game to /game/.
The import is vacant row, it is because of goimports of go-mode that is used in emacs.

If it is useful likely it is fortunate if it is possible to adopt this pull request.

Since this English wrote using Google Translate, it may be wrong.
I'm sorry if there is a mistake.
